### PR TITLE
Added runParallel to run hooks in parallel to Feathers method call.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,14 @@ and are being made available as-is.
 
 We encourage the community to submit hooks they think are useful,
 categorizing them in this README.
-Please read the [contribution guidelines](./CONTRIBUTING.md)
+Please read the [contribution guidelines](./CONTRIBUTING.md).
+See example [hook](./src/run-parallel.js) and [test](./test/run-parallel.test.js).
 
 ## Community hooks
+
+### Transactions
+
+- `runParallel` runs a hook function in parallel to the Feathers method call. **Has tests.**
 
 ## Documentation
 

--- a/src/run-parallel.js
+++ b/src/run-parallel.js
@@ -2,20 +2,20 @@
 /*
  runParallel(func, cloneDepth)
  Run a hook function in parallel to the Feathers method call.
- 
+
  Parameters:
  - `func`       The function to run. Its signature is `func(contextClone)`
  - `cloneDepth` Depth to which the context is to be cloned. Default is 0 = do not clone.
                 A depth of 5 would clone context.result.data.[].item
- 
+
  Notes:
  - Feathers will keep on mutating `contextClone` if that has not been cloned.
- 
+
  Example:
  app.service('users').after({
    create: runParallel(sendSignupEmail())
  });
- 
+
  Author: Original version by bedeoverend
  */
 
@@ -26,10 +26,10 @@ export default function (func, cloneDepth = 0) {
   if (typeof func !== 'function') {
     throw new errors.BadRequest('Function not provided. (delay');
   }
-  
+
   return function (context) {
-    const copy = cloneDepth ? clone(context, true, cloneDepth) : context
-    
-    setTimeout(() => func.call(this, copy))
+    const copy = cloneDepth ? clone(context, true, cloneDepth) : context;
+
+    setTimeout(() => func.call(this, copy));
   };
-};
+}

--- a/test/run-parallel.test.js
+++ b/test/run-parallel.test.js
@@ -2,26 +2,67 @@
 import { assert } from 'chai';
 import runParallel from '../src/run-parallel';
 
+let contextBefore;
 let that;
 
 function test (tester) {
-  return function (context) {
+  return function (contextCloned) {
     that = this;
-    context.params._runParallel = true;
-    tester();
+    tester(contextCloned);
   };
 }
 
 describe('transactions - runParallel', () => {
   beforeEach(() => {
     that = undefined;
+
+    contextBefore = {
+      type: 'before',
+      method: 'create',
+      params: { provider: 'rest' },
+      data: { first: 'John', last: 'Doe' } };
   });
-  
+
   it('runs the func', done => {
-    runParallel(text(tester), 0);
-    
-    function tester() {
+    runParallel(test(tester), 0)(contextBefore);
+
+    function tester () {
       done();
     }
+  });
+
+  it('passes this', done => {
+    runParallel(test(tester), 0).call({ bar: true }, contextBefore);
+
+    function tester () {
+      assert.strictEqual(that.bar, true);
+      done();
+    }
+  });
+
+  it('defaults to uncloned context', done => {
+    runParallel(test(tester))(contextBefore);
+    contextBefore._foo = true;
+
+    function tester (contextCloned) {
+      assert.property(contextCloned, '_foo');
+      done();
+    }
+  });
+
+  it('clones', done => {
+    runParallel(test(tester), 1)(contextBefore);
+    contextBefore._foo = true;
+
+    function tester (contextCloned) {
+      assert.notProperty(contextCloned, '_foo');
+      done();
+    }
+  });
+
+  it('Throws if no func', () => {
+    assert.throws(() => {
+      runParallel()(contextBefore);
+    });
   });
 });


### PR DESCRIPTION
/*
 runParallel(func, cloneDepth)
 Run a hook function in parallel to the Feathers method call.

 Parameters:
 - `func`       The function to run. Its signature is `func(contextClone)`
 - `cloneDepth` Depth to which the context is to be cloned. Default is 0 = do not clone.
                A depth of 5 would clone context.result.data.[].item

 Notes:
 - Feathers will keep on mutating `contextClone` if that has not been cloned.

 Example:
 app.service('users').after({
   create: runParallel(sendSignupEmail())
 });

 Author: Original version by bedeoverend
 */